### PR TITLE
Update CustomSurfaces.c

### DIFF
--- a/CustomCourses/CustomSurfaces.c
+++ b/CustomCourses/CustomSurfaces.c
@@ -125,6 +125,7 @@ void SurfaceSFX(Player *car, int SFX_ID, float min_Speed)
 #define GapJump			235
 #define LavaSurface		234
 #define ForceJump		233
+#define ForceWallTumble		232 //Only use on steep wall surfaces!
 
 #define Mud				18
 
@@ -545,6 +546,16 @@ void AddGravityEdit(Player *car)
 		
 		break;
 	}
+
+	case ForceWallTumble:
+	{
+		if (car->jumpcount == 0 && car->wallhitcount == 0 && !(car->slip_flag&IS_BROKEN))
+		{
+			SetRolloverFall(car,car_number);
+		}
+		break;
+	}
+		
 	default:
 		if (car->max_power != car->bump_status)
 		{

--- a/CustomCourses/CustomSurfaces.c
+++ b/CustomCourses/CustomSurfaces.c
@@ -128,9 +128,12 @@ void SurfaceSFX(Player *car, int SFX_ID, float min_Speed)
 #define ForceWallTumble		232 //Only use on steep wall surfaces!
 
 #define Mud				18
+#define Quicksand		19
 
 
 short SurfaceStorage[8];
+float SurfaceKart3dOffsetY[8];
+float SurfaceTimer[8];
 
 #define STORE_NONE 	0
 #define STORE_TRICK 1
@@ -213,6 +216,45 @@ void AddGravityEdit(Player *car)
 				break;
 			}
 			car->power_cont = 0.65f;
+		}
+		break;
+
+	case Quicksand: 
+		if (car->jumpcount == 0 && car->wallhitcount == 0 && !(car->slip_flag&(IS_STAR|IS_BRAKING)))
+		{
+			SurfaceSFX(car,SFX_SAND_CENTER,10.0f);
+
+			if (car->flag&IS_CPU_PLAYER && car->handling_flag&CPU_SIMPLE_KART) //CPU HANDLING
+			{
+				car->bump_status = 1;
+				SurfaceKart3dOffsetY[car_number] = 0;
+				break;
+			}
+		}	
+
+		if (car->velocity[0] || car->velocity[2]) //CUSTOM DRIVING
+		{
+			SurfaceTimer[car_number] += 0.00001f;
+			
+			car->power_cont = 0.30f + SurfaceTimer[car_number] * 50; //LOSE POWER
+			if (car->power_cont > 0.75f)
+				car->power_cont = 0.75f;
+			
+			SurfaceKart3dOffsetY[car_number] -= 0.01f + sinF(SurfaceTimer[car_number] * pow(GlobalWeight[car_number],2)); //SINK KART (also runkart_hook)
+			
+			if (SurfaceKart3dOffsetY[car_number] < -4.0f) //SUNKEN TIRES -> ADDITIONAL EFFECTS:
+			{
+				car->slip_flag &= ~IS_DRIFTING; //NO DRIFT & TURBO
+				if (car->drift_turbo_timer)
+					car->drift_turbo_timer = 0;
+
+				if (car->turbo_timer) //BAD SHROOM
+					car->turbo_timer = 0;
+
+				//PARTICLE EFFECTS STOP (obj_calculation_hook)
+				//BAD STEERING (ProStickAngleHook)
+				//NO JUMP (jump_set_hook)
+			}
 		}
 		break;
 	}
@@ -588,6 +630,22 @@ void AddGravityEdit(Player *car)
 		break;
 	default:
 		break;
+	}
+
+	if (SurfaceKart3dOffsetY[car_number]) //QUICKSAND RESET ANIM
+	{
+		if (car->bump_status != Quicksand || car->jugemu_flag &ON_LAKITU_ROD)
+		{
+			if (SurfaceKart3dOffsetY[car_number] < 0)
+				SurfaceKart3dOffsetY[car_number] += 0.6f;
+			else if (SurfaceKart3dOffsetY[car_number] > 0)
+				SurfaceKart3dOffsetY[car_number] = 0;
+
+			car->tire_RL.CustomStatus = car->tire_RL.Status;
+			car->tire_RR.CustomStatus = car->tire_RR.Status;
+
+			SurfaceTimer[car_number] = 0;
+		}
 	}
 }
 

--- a/CustomCourses/CustomSurfaces.h
+++ b/CustomCourses/CustomSurfaces.h
@@ -20,4 +20,7 @@ extern void custom_RunKart(Player* car, Camera* camera, char place, char kno);
 extern int LavaFloorBumpCount[];
 extern bool LavaFloorRecoilRequired[];
 extern bool LavaFloorRecoiling[];
+
+extern float SurfaceKart3dOffsetY[];
+extern float SurfaceTimer[];
 #endif

--- a/GameVariables/NTSC/GameOffsets.asm
+++ b/GameVariables/NTSC/GameOffsets.asm
@@ -1296,3 +1296,7 @@
 
 .defineLabel gKartSteerSpeedASM, 0x80150154
 .defineLabel SteeringSpeedData_RT, 0x800E3610
+.defineLabel InitRandSmoke, 0x8005DAF4
+.defineLabel JumpSet, 0x8002AA50
+.defineLabel ObjCalculation, 0x8006D474
+.definelabel DrawShadow, 0x80023C84

--- a/GameVariables/NTSC/GameOffsets.asm
+++ b/GameVariables/NTSC/GameOffsets.asm
@@ -1293,3 +1293,6 @@
 .definelabel EnemyTirePosition, 0x8002A194
 .definelabel SetSlipAngle, 0x8002AE38
 .definelabel NaPlyLandStart, 0x800CADD0
+
+.defineLabel gKartSteerSpeedASM, 0x80150154
+.defineLabel SteeringSpeedData_RT, 0x800E3610

--- a/GameVariables/NTSC/GameOffsets.h
+++ b/GameVariables/NTSC/GameOffsets.h
@@ -1267,3 +1267,7 @@ extern void NaPlyLandStart(char kno, float jumpCount);
 
 extern f32 gKartSteerSpeedASM;//0x80150154
 extern f32 *SteeringSpeedData_RT[8];// 0x800E3610
+extern void InitRandSmoke(Player *car,short count,int kk,char kno,char place);// 0x8005DAF4
+extern void JumpSet(Player *kart);// 0x8002AA50
+extern void ObjCalculation(Player *car,char kno,char place); //8006D474
+extern void DrawShadow(Player *car,char kno,char place);// 0x80023C84

--- a/GameVariables/NTSC/GameOffsets.h
+++ b/GameVariables/NTSC/GameOffsets.h
@@ -1264,3 +1264,6 @@ extern void TirePosition(Player* Car, float new_x, float new_y, float new_z);
 extern void EnemyTirePosition(Player* Car, float new_x, float new_y, float new_z);
 extern void SetSlipAngle(Player* Car, char kno, float old_x, float old_z, float new_x, float new_z);
 extern void NaPlyLandStart(char kno, float jumpCount);
+
+extern f32 gKartSteerSpeedASM;//0x80150154
+extern f32 *SteeringSpeedData_RT[8];// 0x800E3610

--- a/GameVariables/NTSC/StatsOffsets.h
+++ b/GameVariables/NTSC/StatsOffsets.h
@@ -1,6 +1,10 @@
 #ifndef StatsOffsetH
 #define StatsOffsetH
 #include "../../MainInclude.h"
+
+//CUSTOM
+extern float KartHeight[8] = {9.8f,11.10f,10.0f,9.1f,11.5f,10.9f,10.5f,12.f}; //Actual height of player sprite
+
 // UNKNOWN /////////////////////////////////////////////////////
 extern float u11_Mario; // 0x800E24C8
 extern float u11_Luigi; // 0x800E24CC

--- a/LIBRARYBUILD1.asm
+++ b/LIBRARYBUILD1.asm
@@ -262,13 +262,74 @@ NOP
 .halfword 0x0000
 
 
-//AirControlChange
+//ProStickAngle Hook (AirControlChange & Steering)
 .org 0x38A04
 NOP
 .org 0x38A10
 JAL ProStickAngleHook
 .org 0x38A4C
 NOP
+//ProStickAngle ASM Change (Force use of custom global steering val: gKartSteerSpeedASM 0x80150154)
+.org 0x0349FC
+lui   $at, hi(0x80150154) //gKartSteerSpeedASM
+addiu $at, lo(0x80150154)
+lwc1  $f16, ($at)
+.org 0x034A28
+add.s $f2, $f10, $f16
+nop
+.org 0x034A64
+nop
+
+//Init Random Smoke Hook 
+.org 0x06D59C
+JAL InitRandSmokeHook
+//Init Random Smoke Change (load custom tire struct char)
+.org 0x05E75C
+lbu   $t1, 0x1dc($s1) 
+.org 0x05E7AC
+lbu   $t1, 0x1f4($s1)
+
+//Player Jump Hook 
+.org 0x0389C0
+JAL JumpSetHook
+.org 0x0389EC //NOP jump sfx -> Do in JumpSetHook
+nop
+
+//Effect Object Calculation Hook 
+.org 0x06F1FC
+JAL ObjCalculationHook
+.org 0x06F20C
+JAL ObjCalculationHook
+.org 0x06F284
+JAL ObjCalculationHook
+.org 0x06F294
+JAL ObjCalculationHook
+.org 0x06F30C
+JAL ObjCalculationHook
+.org 0x06F31C
+JAL ObjCalculationHook
+.org 0x06F394
+JAL ObjCalculationHook
+.org 0x06F3A4
+JAL ObjCalculationHook
+
+//Draw Kart Shadow Hook
+.org 0x0274F0
+JAL DrawShadowHook
+.org 0x027510
+JAL DrawShadowHook
+
+//Run Kart Hook
+.org 0x029798
+JAL RunKartHook
+.org 0x0297FC
+JAL RunKartHook
+.org 0x02990C
+JAL RunKartHook
+.org 0x029A48
+JAL RunKartHook
+
+
 
 //Print Menu Hooks
 .org 0x2B30

--- a/Player/PlayerChecks.c
+++ b/Player/PlayerChecks.c
@@ -558,3 +558,12 @@ void LakituSpawnBypass(Player *Kart, char PlayerID, float *SpawnVector, float *F
 	}
 	
 }
+
+void RunKartHook (Player *car,Camera *camera,char place,char kno)
+{
+	car->position[1] -= SurfaceKart3dOffsetY[kno];
+
+	RunKart(car,camera,place,kno);
+
+	car->position[1] += SurfaceKart3dOffsetY[kno];
+}

--- a/Struct.h
+++ b/Struct.h
@@ -363,7 +363,15 @@ typedef struct Tire //size: 0x18 * [4] | inside player struct
 	unsigned char 	LastAxis;		//0D
 	ushort 			LastPointer;	//0E
 	float 			Height;			//10
-	int  			Dummy;			//14 0000 0000 0000 00001:KAGE ON	
+	union {
+	        struct {
+	            uchar CustomStatus; //14 WE CAN USE THESE 3, CAUSE THEY ALWAYS DO BITWISE CHECKS FOR "DUMMY"
+	            uchar DummyUnused1; //15
+	            uchar DummyUnused2; //16
+		    uchar DummyUsed; 	//17 DON'T USE THIS ONE SEE BELOW
+	        };
+	        int Dummy; //14 LAST 2? BITS ARE USED -> NO DUMMY! (E.G. LUIGI TUNNEL LIGHT! VALUES 1-3)
+	};	
 } Tire;
 
 typedef struct Smoke //size: 0x48


### PR DESCRIPTION
New custom surface #232 ForceWallTumble:
- Prevent players from falling through geometry on the (steep) outer bounds of courses
- Prevent players from reaching/shortcutting areas by jumping up hills

New custom surface #19 Quicksand:
- Player sinks under sand with power loss and no kart shadow
- Once the tires are under the sand: No jump, no drift & turbo, bad shrooming, bad steering, no particle effects